### PR TITLE
s10 changes

### DIFF
--- a/ProjectD2/PlugY.ini
+++ b/ProjectD2/PlugY.ini
@@ -121,7 +121,7 @@ PosYStashGoldField=36
 ActiveStatsUnassignment=1
 KeyUsed=18
 
-ActiveShiftClickLimit=1
+ActiveShiftClickLimit=0
 LimitValueToShiftClick=20
 
 


### PR DESCRIPTION
disabled ActiveShiftClickLimit to prevent crashes after s10 update.